### PR TITLE
Remove GraalVM prerequisite and use Maven wrapper for release

### DIFF
--- a/release-perform.sh
+++ b/release-perform.sh
@@ -22,7 +22,7 @@ echo "Deploying release"
 
 export MAVEN_OPTS="-Dmaven.repo.local=$(realpath ../repository)"
 
-mvn clean deploy \
+./mvnw clean deploy \
  -Dscan=false \
  -Dgradle.cache.local.enabled=false \
  -DskipTests -DskipITs \

--- a/release-prepare.sh
+++ b/release-prepare.sh
@@ -44,7 +44,7 @@ echo "Update version to ${VERSION}"
 
 export MAVEN_OPTS="-Dmaven.repo.local=$(realpath ../repository)"
 
-mvn \
+./mvnw \
   clean install \
   -Dscan=false \
   -Dgradle.cache.local.enabled=false \

--- a/release-prepare.sh
+++ b/release-prepare.sh
@@ -24,12 +24,6 @@ else
   BRANCH="HEAD"
 fi
 
-if [ -z "${GRAALVM_HOME}" ]
-  then
-    echo "GRAALVM_HOME must be defined"
-    exit 2
-fi
-
 echo "Preparing release ${VERSION} on branch ${BRANCH}"
 
 echo "Cloning quarkus"


### PR DESCRIPTION
We don't need GraalVM to release Quarkus.