### PR TITLE
Enforce using Java 21 for scripts

### DIFF
--- a/postcorerelease.java
+++ b/postcorerelease.java
@@ -3,6 +3,7 @@
 //DEPS io.quarkus:quarkus-picocli
 //DEPS org.kohsuke:github-api:1.315
 
+//JAVA 21
 //JAVAC_OPTIONS -parameters
 //JAVA_OPTIONS -Djava.util.logging.manager=org.jboss.logmanager.LogManager
 

--- a/postplatformrelease.java
+++ b/postplatformrelease.java
@@ -3,6 +3,7 @@
 //DEPS io.quarkus:quarkus-picocli
 //DEPS org.kohsuke:github-api:1.321
 
+//JAVA 21
 //JAVAC_OPTIONS -parameters
 //JAVA_OPTIONS -Djava.util.logging.manager=org.jboss.logmanager.LogManager
 

--- a/prerequisites.java
+++ b/prerequisites.java
@@ -4,6 +4,7 @@
 //DEPS org.kohsuke:github-api:1.315
 //DEPS org.apache.maven:maven-artifact:3.9.6
 
+//JAVA 21
 //JAVAC_OPTIONS -parameters
 //JAVA_OPTIONS -Djava.util.logging.manager=org.jboss.logmanager.LogManager
 

--- a/togglemainprotection.java
+++ b/togglemainprotection.java
@@ -3,6 +3,7 @@
 //DEPS io.quarkus:quarkus-picocli
 //DEPS org.kohsuke:github-api:1.315
 
+//JAVA 21
 //JAVAC_OPTIONS -parameters
 //JAVA_OPTIONS -Djava.util.logging.manager=org.jboss.logmanager.LogManager
 

--- a/updateextensioncatalog.java
+++ b/updateextensioncatalog.java
@@ -3,6 +3,7 @@
 //DEPS io.quarkus:quarkus-picocli
 //DEPS org.kohsuke:github-api:1.315
 
+//JAVA 21
 //JAVAC_OPTIONS -parameters
 //JAVA_OPTIONS -Djava.util.logging.manager=org.jboss.logmanager.LogManager
 
@@ -10,13 +11,7 @@
 //Q:CONFIG quarkus.banner.enabled=false
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Optional;
 
-import org.kohsuke.github.GHIssueState;
-import org.kohsuke.github.GHMilestone;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHWorkflow;
 import org.kohsuke.github.GitHub;


### PR DESCRIPTION
Some of the scripts are not compatible with Java 11 anymore but we still need to be able to release with Java 11 so just forcing JBang to use Java 21 for the scripts.