### PR TITLE
Add quarkus-documentation-rag to the release mapping

### DIFF
--- a/mapping.properties
+++ b/mapping.properties
@@ -1,6 +1,7 @@
 quarkusio/build-reporter=io.quarkus.bot
 quarkusio/gizmo=io.quarkus.gizmo
 quarkusio/quarkus-agent-mcp=io.quarkus
+quarkusio/quarkus-documentation-rag=io.quarkus
 quarkusio/quarkus-fs-util=io.quarkus
 quarkusio/quarkus-http=io.quarkus.http
 quarkusio/quarkus-platform-bom-generator=io.quarkus


### PR DESCRIPTION
Adds the new `quarkusio/quarkus-documentation-rag` repository to the groupId mapping so it can publish artifacts under `io.quarkus` via the standard release workflow.

This repo contains the Maven plugin and core library for generating RAG vector embeddings from Quarkus documentation, replacing the monolithic chappie-docling-rag pipeline.